### PR TITLE
Increased buffer on watcher to decrease missed events.

### DIFF
--- a/pswatch.psm1
+++ b/pswatch.psm1
@@ -54,6 +54,7 @@ function watch{
 	$watcher.IncludeSubdirectories = $includeSubdirectories
 	$watcher.EnableRaisingEvents = $false
 	$watcher.NotifyFilter = [System.IO.NotifyFilters]::LastWrite -bor [System.IO.NotifyFilters]::FileName
+	$watcher.InternalBufferSize = 61440
 	
 	$conditions = 0
 	if($includeChanged){


### PR DESCRIPTION
I've increased the internal buffer of the watcher in order to decrease the number of missed events.  The default is 8k and saving two files simultaneously was only show one change from the watcher.  It's unclear to me why 8k isn't enough of a buffer, but increasing it fixes the problem.  There is documentation on msdn about buffer overruns and lost events.  As well, to set a value that is an increment of 4k and a warning not to exceed 65k.  Which is why I shot for 4k under.  Anyway, this project perfect for what I needed it for.  Thanks!